### PR TITLE
Implement robust JSON canonicalization and tests

### DIFF
--- a/src/ai_trust/core/canonicalization/__init__.py
+++ b/src/ai_trust/core/canonicalization/__init__.py
@@ -1,32 +1,93 @@
-"""Canonicalization of data for consistent hashing and signing."""
+"""Canonicalization utilities following JSON Canonicalization Scheme (RFC 8785)."""
+
+from __future__ import annotations
+
 import json
+import math
 import unicodedata
+from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any
 
 
-def canonicalize(data: Any) -> str:
-    """Convert data to a canonical JSON string with NFC normalization.
+class CanonicalizationError(Exception):
+    """Raised when data cannot be canonicalized."""
 
-    Args:
-        data: The data to canonicalize (must be JSON-serializable)
 
-    Returns:
-        str: Canonical JSON string with NFC normalization
-    """
+def _normalize(value: Any) -> Any:
+    """Recursively normalise a value for canonical JSON serialisation."""
 
-    def _canonicalize_value(value: Any) -> Any:
-        if isinstance(value, str):
-            return unicodedata.normalize("NFC", value)
-        if isinstance(value, dict):
-            return {k: _canonicalize_value(v) for k, v in value.items()}
-        if isinstance(value, (list, tuple)):
-            return [_canonicalize_value(v) for v in value]
+    if isinstance(value, str):
+        # Apply NFC normalization for Unicode strings
+        return unicodedata.normalize("NFC", value)
+
+    if isinstance(value, bool) or value is None or isinstance(value, int):
         return value
 
-    canonical_data = _canonicalize_value(data)
-    return json.dumps(
-        canonical_data,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
+    if isinstance(value, float):
+        # RFC 8785: reject NaN/Infinity and emit the most compact form
+        if not math.isfinite(value):
+            raise CanonicalizationError("Non-finite float values are not allowed")
+        if value.is_integer():
+            return int(value)
+        # Convert through Decimal to avoid scientific notation
+        return float(Decimal(str(value)))
+
+    if isinstance(value, datetime):
+        # Convert to UTC and RFC3339 format without superfluous zeros
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        value = value.astimezone(timezone.utc)
+        iso = value.isoformat(timespec="microseconds").replace("+00:00", "Z")
+        if "." in iso:
+            main, rest = iso.split(".", 1)
+            frac, _ = rest.split("Z")
+            frac = frac.rstrip("0")
+            iso = main + ("." + frac if frac else "") + "Z"
+        return iso
+
+    if isinstance(value, (list, tuple)):
+        return [_normalize(v) for v in value]
+
+    if isinstance(value, dict):
+        # Ensure all keys are strings
+        if any(not isinstance(k, str) for k in value):
+            raise CanonicalizationError("Dictionary keys must be strings")
+        return {k: _normalize(v) for k, v in value.items()}
+
+    raise CanonicalizationError(f"Type {type(value)!r} is not supported for canonicalization")
+
+
+def canonicalize(data: Any) -> str:
+    """Convert data to a canonical JSON string.
+
+    The implementation performs Unicode NFC normalisation and follows the
+    JSON Canonicalization Scheme (RFC 8785) for numbers and datetimes.
+    """
+
+    canonical_data = _normalize(data)
+    try:
+        return json.dumps(
+            canonical_data,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise CanonicalizationError(str(exc)) from exc
+
+
+def canonical_json_dumps(data: Any) -> str:
+    """Convenience wrapper for :func:`canonicalize`."""
+
+    return canonicalize(data)
+
+
+def verify_canonical_equivalence(a: Any, b: Any) -> bool:
+    """Return True if two objects canonicalize to the same JSON string."""
+
+    try:
+        return canonicalize(a) == canonicalize(b)
+    except CanonicalizationError:
+        return False

--- a/tests/unit/test_canonicalization.py
+++ b/tests/unit/test_canonicalization.py
@@ -1,0 +1,27 @@
+import pytest
+from datetime import datetime, timezone
+
+from ai_trust.core.canonicalization import canonicalize, CanonicalizationError
+
+
+def test_canonicalize_floats():
+    assert canonicalize(1e6) == "1000000"
+    assert canonicalize(1.23e-4) == "0.000123"
+    assert canonicalize(42.0) == "42"
+    with pytest.raises(CanonicalizationError):
+        canonicalize(float("nan"))
+
+
+def test_canonicalize_datetimes():
+    dt = datetime(2023, 5, 1, 12, 30, 0, 123000, tzinfo=timezone.utc)
+    assert canonicalize(dt) == '"2023-05-01T12:30:00.123Z"'
+
+    dt_naive = datetime(2023, 5, 1, 12, 30, 0)
+    assert canonicalize(dt_naive) == '"2023-05-01T12:30:00Z"'
+
+
+def test_unicode_normalization():
+    # The composed and decomposed forms of "é" should canonicalize identically
+    composed = "é"
+    decomposed = "e\u0301"
+    assert canonicalize(composed) == canonicalize(decomposed)


### PR DESCRIPTION
## Summary
- expand canonicalization to follow RFC 8785: NFC normalization, float handling, and RFC3339 datetimes
- add helper utilities and equivalence check
- cover float, datetime, and Unicode cases with unit tests

## Testing
- `pytest tests/unit/test_core.py tests/unit/test_canonicalization.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b634909b80832fb3cb663f553f5e63