### PR TITLE
Add verifiable receipt schema and pocket verifier

### DIFF
--- a/schema/receipt.schema.json
+++ b/schema/receipt.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/ai-trust/receipt.schema.json",
+  "title": "AI Trust Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version","issued_at","nonce","alg","hash_alg","kid","task_hash","model_hash",
+    "input_commitment","output_commitment","policies","costs","canonical_hash","signature","transparency"
+  ],
+  "properties": {
+    "schema_version": {"$ref": "#/$defs/schema_version"},
+    "issued_at": {"$ref": "#/$defs/issued_at"},
+    "nonce": {"$ref": "#/$defs/nonce"},
+    "alg": {"$ref": "#/$defs/alg"},
+    "hash_alg": {"$ref": "#/$defs/hash_alg"},
+    "kid": {"$ref": "#/$defs/kid"},
+    "task_hash": {"$ref": "#/$defs/hash"},
+    "model_hash": {"$ref": "#/$defs/hash"},
+    "input_commitment": {"$ref": "#/$defs/hash"},
+    "output_commitment": {"$ref": "#/$defs/hash"},
+    "policies": {"$ref": "#/$defs/policies"},
+    "costs": {"$ref": "#/$defs/costs"},
+    "payload_summary": {"$ref": "#/$defs/payload_summary"},
+    "canonical_hash": {"$ref": "#/$defs/hash"},
+    "signature": {"$ref": "#/$defs/signature"},
+    "transparency": {"$ref": "#/$defs/transparency"}
+  },
+  "$defs": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "Semantic version of the receipt schema"
+    },
+    "issued_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$",
+      "description": "Timestamp in ISO 8601 UTC with milliseconds"
+    },
+    "nonce": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{22,24}$",
+      "description": "128-bit random nonce encoded with base64url"
+    },
+    "alg": {
+      "type": "string",
+      "enum": ["Ed25519"],
+      "description": "Signature algorithm"
+    },
+    "hash_alg": {
+      "type": "string",
+      "enum": ["SHA-256"],
+      "description": "Hash algorithm"
+    },
+    "kid": {
+      "type": "string",
+      "pattern": "^[A-Fa-f0-9]{64}$|^did:key:[A-Za-z0-9:_-]+$",
+      "description": "Key identifier"
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "SHA-256 hash encoded in base64url with prefix"
+    },
+    "policies": {
+      "type": "object",
+      "required": ["satisfied","relaxed"],
+      "additionalProperties": false,
+      "properties": {
+        "satisfied": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^[A-Z0-9_]+$"},
+          "default": []
+        },
+        "relaxed": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^[A-Z0-9_]+$"},
+          "default": []
+        }
+      },
+      "description": "Policy identifiers satisfied or relaxed"
+    },
+    "costs": {
+      "type": "object",
+      "required": ["latency_ms","energy_j"],
+      "additionalProperties": false,
+      "properties": {
+        "latency_ms": {"type": "integer", "minimum": 0, "default": 0},
+        "energy_j": {"type": "number", "minimum": 0, "default": 0}
+      },
+      "description": "Cost metrics"
+    },
+    "payload_summary": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{0,88}$",
+      "description": "Optional base64url summary of prompt"
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{86}$",
+      "description": "Ed25519 signature base64url without padding"
+    },
+    "transparency": {
+      "type": "object",
+      "required": ["log_id","leaf_hash","tree_size","inclusion_proof"],
+      "additionalProperties": false,
+      "properties": {
+        "log_id": {"type": "string"},
+        "leaf_hash": {"$ref": "#/$defs/hash"},
+        "tree_size": {"type": "integer", "minimum": 0},
+        "inclusion_proof": {
+          "type": "object",
+          "required": ["leaf_index","path","path_directions"],
+          "additionalProperties": false,
+          "properties": {
+            "leaf_index": {"type": "integer", "minimum": 0},
+            "path": {
+              "type": "array",
+              "items": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43,}$"},
+              "default": []
+            },
+            "path_directions": {"type": "string", "pattern": "^[LR]*$", "default": ""}
+          }
+        }
+      },
+      "description": "Transparency log metadata"
+    }
+  }
+}

--- a/tests/data/receipts/input_nfd.json
+++ b/tests/data/receipts/input_nfd.json
@@ -1,0 +1,1 @@
+{"prompt": "Hello Café"}

--- a/tests/data/receipts/invalid_issued_at_offset.json
+++ b/tests/data/receipts/invalid_issued_at_offset.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2025-09-01T19:07:00.123+01:00",
+  "nonce": "P_99Yr6Qdg43NXF58lZ8rA",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "c72de6fe5cf8fc26ab73b04ad2352e7d88f7444994b632d0f977fbc2ed18e140",
+  "task_hash": "sha256:aQ-bIVb1ZU_6WMGtcdgVGuMrh2gyaK70VLuj79WUZ4I",
+  "model_hash": "sha256:LBevwd8jQpf8V6Ocmxi_UKRIeO1nvKhsPwDbGRTh98c",
+  "input_commitment": "sha256:7dRKmjloa_N4BYm5-KU4LGmN3pwdqkba1LPAKq06HfU",
+  "output_commitment": "sha256:hhSbl6v-j5nlLFXK_ZH81BUUXvyTSveZuw3IPgLv_co",
+  "policies": {
+    "satisfied": [
+      "P_SAFE_001"
+    ],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 0.5
+  },
+  "payload_summary": "",
+  "canonical_hash": "sha256:CPTAC6NWAI31zum2yxTvRAHHJFm9Vk0K7pQVuU-g9Pc",
+  "signature": "1AWBX8ejf-d7FwedirZSny0aAL0pHFxq5eESBt3YzmmzNp5rA9fc3tE7b53cGHUURJZhlo55YjRPQL5PwSRlAA",
+  "transparency": {
+    "log_id": "log1",
+    "leaf_hash": "sha256:jwGkGjipsB04vyNrzWthmmLSq4Sk6q2Q4yXol0xbCGU",
+    "tree_size": 0,
+    "inclusion_proof": {
+      "leaf_index": 0,
+      "path": [],
+      "path_directions": ""
+    }
+  }
+}

--- a/tests/data/receipts/invalid_nonce.json
+++ b/tests/data/receipts/invalid_nonce.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2025-09-01T19:07:00.123Z",
+  "nonce": "short",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "c72de6fe5cf8fc26ab73b04ad2352e7d88f7444994b632d0f977fbc2ed18e140",
+  "task_hash": "sha256:aQ-bIVb1ZU_6WMGtcdgVGuMrh2gyaK70VLuj79WUZ4I",
+  "model_hash": "sha256:LBevwd8jQpf8V6Ocmxi_UKRIeO1nvKhsPwDbGRTh98c",
+  "input_commitment": "sha256:7dRKmjloa_N4BYm5-KU4LGmN3pwdqkba1LPAKq06HfU",
+  "output_commitment": "sha256:hhSbl6v-j5nlLFXK_ZH81BUUXvyTSveZuw3IPgLv_co",
+  "policies": {
+    "satisfied": [
+      "P_SAFE_001"
+    ],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 0.5
+  },
+  "payload_summary": "",
+  "canonical_hash": "sha256:CPTAC6NWAI31zum2yxTvRAHHJFm9Vk0K7pQVuU-g9Pc",
+  "signature": "1AWBX8ejf-d7FwedirZSny0aAL0pHFxq5eESBt3YzmmzNp5rA9fc3tE7b53cGHUURJZhlo55YjRPQL5PwSRlAA",
+  "transparency": {
+    "log_id": "log1",
+    "leaf_hash": "sha256:jwGkGjipsB04vyNrzWthmmLSq4Sk6q2Q4yXol0xbCGU",
+    "tree_size": 0,
+    "inclusion_proof": {
+      "leaf_index": 0,
+      "path": [],
+      "path_directions": ""
+    }
+  }
+}

--- a/tests/data/receipts/output.json
+++ b/tests/data/receipts/output.json
@@ -1,0 +1,1 @@
+{"response": "World"}

--- a/tests/data/receipts/test_jwks.json
+++ b/tests/data/receipts/test_jwks.json
@@ -1,0 +1,9 @@
+{
+  "keys": [
+    {
+      "kid": "c72de6fe5cf8fc26ab73b04ad2352e7d88f7444994b632d0f977fbc2ed18e140",
+      "alg": "Ed25519",
+      "public": "CmHEOF0eZd3L0fk_KR--W_Eyt5emIJYurtNN6p1ibzE"
+    }
+  ]
+}

--- a/tests/data/receipts/unicode_commitment.json
+++ b/tests/data/receipts/unicode_commitment.json
@@ -1,0 +1,5 @@
+{
+  "nfd": "Hello Café",
+  "nfc": "Hello Café",
+  "commitment": "sha256:7dRKmjloa_N4BYm5-KU4LGmN3pwdqkba1LPAKq06HfU"
+}

--- a/tests/data/receipts/valid_receipt.json
+++ b/tests/data/receipts/valid_receipt.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2025-09-01T19:07:00.123Z",
+  "nonce": "P_99Yr6Qdg43NXF58lZ8rA",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "c72de6fe5cf8fc26ab73b04ad2352e7d88f7444994b632d0f977fbc2ed18e140",
+  "task_hash": "sha256:aQ-bIVb1ZU_6WMGtcdgVGuMrh2gyaK70VLuj79WUZ4I",
+  "model_hash": "sha256:LBevwd8jQpf8V6Ocmxi_UKRIeO1nvKhsPwDbGRTh98c",
+  "input_commitment": "sha256:7dRKmjloa_N4BYm5-KU4LGmN3pwdqkba1LPAKq06HfU",
+  "output_commitment": "sha256:hhSbl6v-j5nlLFXK_ZH81BUUXvyTSveZuw3IPgLv_co",
+  "policies": {
+    "satisfied": [
+      "P_SAFE_001"
+    ],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 0.5
+  },
+  "payload_summary": "",
+  "canonical_hash": "sha256:CPTAC6NWAI31zum2yxTvRAHHJFm9Vk0K7pQVuU-g9Pc",
+  "signature": "1AWBX8ejf-d7FwedirZSny0aAL0pHFxq5eESBt3YzmmzNp5rA9fc3tE7b53cGHUURJZhlo55YjRPQL5PwSRlAA",
+  "transparency": {
+    "log_id": "log1",
+    "leaf_hash": "sha256:jwGkGjipsB04vyNrzWthmmLSq4Sk6q2Q4yXol0xbCGU",
+    "tree_size": 0,
+    "inclusion_proof": {
+      "leaf_index": 0,
+      "path": [],
+      "path_directions": ""
+    }
+  }
+}

--- a/tests/test_pocket_verifier.py
+++ b/tests/test_pocket_verifier.py
@@ -1,0 +1,37 @@
+import json
+from verifier.pocket_verifier import verify, load_jwks, jcs, b64url_encode
+
+
+def load(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def test_valid_receipt():
+    jwks = load_jwks('tests/data/receipts/test_jwks.json')
+    receipt = load('tests/data/receipts/valid_receipt.json')
+    input_data = load('tests/data/receipts/input_nfd.json')
+    output_data = load('tests/data/receipts/output.json')
+    ok, reasons = verify(receipt, jwks, input_data, output_data)
+    assert ok, reasons
+
+
+def test_invalid_nonce():
+    jwks = load_jwks('tests/data/receipts/test_jwks.json')
+    receipt = load('tests/data/receipts/invalid_nonce.json')
+    ok, reasons = verify(receipt, jwks)
+    assert not ok
+
+
+def test_invalid_issued_at():
+    jwks = load_jwks('tests/data/receipts/test_jwks.json')
+    receipt = load('tests/data/receipts/invalid_issued_at_offset.json')
+    ok, reasons = verify(receipt, jwks)
+    assert not ok
+
+
+def test_unicode_commitment_vector():
+    vec = load('tests/data/receipts/unicode_commitment.json')
+    data = {'prompt': vec['nfd']}
+    commit = 'sha256:' + b64url_encode(__import__('hashlib').sha256(jcs(data).encode()).digest())
+    assert commit == vec['commitment']

--- a/verifier/pocket_verifier.py
+++ b/verifier/pocket_verifier.py
@@ -1,94 +1,102 @@
-"""
-Pocket verifier for AI receipts (v0).
+#!/usr/bin/env python3
+"""Minimal offline verifier for AI Trust receipts."""
+import argparse, base64, json, struct, hashlib, sys, unicodedata
+from datetime import datetime, timezone
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jsonschema import validate, ValidationError
 
-Validates: schema subset, canonical JSON signature with Ed25519, body_sha256 binding.
-Log proofs are optional in this minimal build.
-"""
-from __future__ import annotations
+SCHEMA = json.loads(r'''{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://example.com/ai-trust/receipt.schema.json","title":"AI Trust Receipt","type":"object","additionalProperties":false,"required":["schema_version","issued_at","nonce","alg","hash_alg","kid","task_hash","model_hash","input_commitment","output_commitment","policies","costs","canonical_hash","signature","transparency"],"properties":{"schema_version":{"$ref":"#/$defs/schema_version"},"issued_at":{"$ref":"#/$defs/issued_at"},"nonce":{"$ref":"#/$defs/nonce"},"alg":{"$ref":"#/$defs/alg"},"hash_alg":{"$ref":"#/$defs/hash_alg"},"kid":{"$ref":"#/$defs/kid"},"task_hash":{"$ref":"#/$defs/hash"},"model_hash":{"$ref":"#/$defs/hash"},"input_commitment":{"$ref":"#/$defs/hash"},"output_commitment":{"$ref":"#/$defs/hash"},"policies":{"$ref":"#/$defs/policies"},"costs":{"$ref":"#/$defs/costs"},"payload_summary":{"$ref":"#/$defs/payload_summary"},"canonical_hash":{"$ref":"#/$defs/hash"},"signature":{"$ref":"#/$defs/signature"},"transparency":{"$ref":"#/$defs/transparency"}},"$defs":{"schema_version":{"type":"string","pattern":"^\\d+\\.\\d+$","description":"Semantic version of the receipt schema"},"issued_at":{"type":"string","pattern":"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$","description":"Timestamp in ISO 8601 UTC with milliseconds"},"nonce":{"type":"string","pattern":"^[A-Za-z0-9_-]{22,24}$","description":"128-bit random nonce encoded with base64url"},"alg":{"type":"string","enum":["Ed25519"],"description":"Signature algorithm"},"hash_alg":{"type":"string","enum":["SHA-256"],"description":"Hash algorithm"},"kid":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$|^did:key:[A-Za-z0-9:_-]+$","description":"Key identifier"},"hash":{"type":"string","pattern":"^sha256:[A-Za-z0-9_-]{43,}$","description":"SHA-256 hash encoded in base64url with prefix"},"policies":{"type":"object","required":["satisfied","relaxed"],"additionalProperties":false,"properties":{"satisfied":{"type":"array","items":{"type":"string","pattern":"^[A-Z0-9_]+$"},"default":[]},"relaxed":{"type":"array","items":{"type":"string","pattern":"^[A-Z0-9_]+$"},"default":[]}},"description":"Policy identifiers satisfied or relaxed"},"costs":{"type":"object","required":["latency_ms","energy_j"],"additionalProperties":false,"properties":{"latency_ms":{"type":"integer","minimum":0,"default":0},"energy_j":{"type":"number","minimum":0,"default":0}},"description":"Cost metrics"},"payload_summary":{"type":"string","pattern":"^[A-Za-z0-9_-]{0,88}$","description":"Optional base64url summary of prompt"},"signature":{"type":"string","pattern":"^[A-Za-z0-9_-]{86}$","description":"Ed25519 signature base64url without padding"},"transparency":{"type":"object","required":["log_id","leaf_hash","tree_size","inclusion_proof"],"additionalProperties":false,"properties":{"log_id":{"type":"string"},"leaf_hash":{"$ref":"#/$defs/hash"},"tree_size":{"type":"integer","minimum":0},"inclusion_proof":{"type":"object","required":["leaf_index","path","path_directions"],"additionalProperties":false,"properties":{"leaf_index":{"type":"integer","minimum":0},"path":{"type":"array","items":{"type":"string","pattern":"^[A-Za-z0-9_-]{43,}$"},"default":[]},"path_directions":{"type":"string","pattern":"^[LR]*$","default":""}}}},"description":"Transparency log metadata"}}}''')
 
-import argparse
-import base64
-import hashlib
-import json
-import sys
-from typing import Any
+DOMAIN = b"ai-trust-v1"
 
-try:
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-    from cryptography.exceptions import InvalidSignature
-    HAVE_CRYPTO = True
-except Exception:
-    HAVE_CRYPTO = False
 
-def b64url_decode(s: str) -> bytes:
-    s = s.replace('-', '+').replace('_', '/')
-    pad = '=' * ((4 - len(s) % 4) % 4)
-    return base64.b64decode(s + pad)
+def b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=="[: (4 - len(data) % 4) % 4])
 
-def canonical_json(obj: Any) -> bytes:
-    def _canon(v):
-        if v is None: return "null"
-        if v is True: return "true"
-        if v is False: return "false"
-        if isinstance(v, (int, float)):
-            if isinstance(v, float) and (v != v or v in (float('inf'), float('-inf'))):
-                raise ValueError("non-finite number")
-            s = repr(v)
-            if s.endswith('.0'): s = s[:-2]
-            return s
-        if isinstance(v, str): return json.dumps(v, ensure_ascii=False, separators=(',', ':'))
-        if isinstance(v, list): return "[" + ",".join(_canon(x) for x in v) + "]"
-        if isinstance(v, dict):
-            return "{" + ",".join(json.dumps(k, ensure_ascii=False, separators=(',', ':')) + ":" + _canon(v[k]) for k in sorted(v)) + "}"
-        raise TypeError(f"unsupported type {type(v)}")
-    return _canon(obj).encode('utf-8')
 
-def verify_signature(receipt: dict, body_bytes: bytes) -> tuple[bool, str]:
-    sig_block = receipt.get("signature") or {}
-    alg = sig_block.get("alg")
-    kid = sig_block.get("kid")
-    sig_b64 = sig_block.get("sig")
-    if alg != "Ed25519" or not sig_b64 or not kid:
-        return False, "signature block missing required fields"
-    to_sign = dict(receipt)
-    to_sign.pop("signature", None)
-    msg = b"AI-Receipt-v0\n" + canonical_json(to_sign)
-    sig = b64url_decode(sig_b64)
-    # Minimal key resolution for demo: expect debug_public_key_b64url at top-level
-    pk_b64 = receipt.get("debug_public_key_b64url")
-    if not pk_b64:
-        return False, "no key resolution in demo; include debug_public_key_b64url"
-    if not HAVE_CRYPTO:
-        return False, "cryptography not available"
+def b64url_encode(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).decode().rstrip("=")
+
+
+def jcs(obj):
+    if isinstance(obj, dict):
+        return "{" + ",".join(f"{json.dumps(unicodedata.normalize('NFC',k),ensure_ascii=False)}:{jcs(v)}" for k, v in sorted(obj.items())) + "}"
+    if isinstance(obj, list):
+        return "[" + ",".join(jcs(x) for x in obj) + "]"
+    if isinstance(obj, str):
+        return json.dumps(unicodedata.normalize('NFC', obj), ensure_ascii=False, separators=(',',':'))
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        if obj == -0.0:
+            obj = 0.0
+        if obj != obj or obj in (float('inf'), float('-inf')):
+            raise ValueError("invalid float")
+        return json.dumps(obj, ensure_ascii=False, separators=(',',':'))
+    if obj is None:
+        return "null"
+    raise TypeError("unsupported type")
+
+
+def load_jwks(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return {k['kid']: k for k in data.get('keys', [])}
+
+
+def verify(receipt, jwks, input_data=None, output_data=None):
+    reasons = []
     try:
-        pk = Ed25519PublicKey.from_public_bytes(b64url_decode(pk_b64))
-        pk.verify(sig, msg)
-    except InvalidSignature:
-        return False, "invalid signature"
-    return True, "ok"
+        validate(receipt, SCHEMA)
+    except ValidationError as e:
+        reasons.append(f"schema:{e.message}")
+        return False, reasons
+    payload_keys = ['schema_version','issued_at','nonce','alg','hash_alg','kid','task_hash','model_hash','input_commitment','output_commitment','policies','costs']
+    payload = {k: receipt[k] for k in payload_keys}
+    jcs_bytes = jcs(payload).encode()
+    expected_hash = 'sha256:' + b64url_encode(hashlib.sha256(jcs_bytes).digest())
+    if receipt['canonical_hash'] != expected_hash:
+        reasons.append('canonical_hash')
+    if input_data is not None:
+        commit = 'sha256:' + b64url_encode(hashlib.sha256(jcs(input_data).encode()).digest())
+        if commit != receipt['input_commitment']:
+            reasons.append('input_commitment')
+    if output_data is not None:
+        commit = 'sha256:' + b64url_encode(hashlib.sha256(jcs(output_data).encode()).digest())
+        if commit != receipt['output_commitment']:
+            reasons.append('output_commitment')
+    key = jwks.get(receipt['kid'])
+    if not key:
+        reasons.append('kid')
+    else:
+        ts = datetime.strptime(receipt['issued_at'], '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=timezone.utc)
+        frame = DOMAIN + struct.pack('>Q', int(ts.timestamp()*1000)) + b64url_decode(receipt['nonce']) + jcs_bytes
+        try:
+            pub = Ed25519PublicKey.from_public_bytes(b64url_decode(key['public']))
+            pub.verify(b64url_decode(receipt['signature']), frame)
+        except Exception:
+            reasons.append('signature')
+    return len(reasons)==0, reasons
 
-def verify_body_hash(receipt: dict, body_bytes: bytes) -> tuple[bool, str]:
-    out = receipt.get("output") or {}
-    h = out.get("body_sha256")
-    if not h: return False, "missing output.body_sha256"
-    calc = hashlib.sha256(body_bytes).hexdigest()
-    if calc != h: return False, f"body hash mismatch: expected {h}, got {calc}"
-    return True, "ok"
 
 def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--receipt", required=True)
-    p.add_argument("--body-file", required=True)
-    args = p.parse_args()
-    rcpt = json.load(open(args.receipt, "r", encoding="utf-8"))
-    body = open(args.body_file, "rb").read()
-    ok, why = verify_body_hash(rcpt, body)
-    if not ok:
-        print(json.dumps({"ok": False, "stage": "body_hash", "reason": why}, ensure_ascii=False)); sys.exit(2)
-    ok, why = verify_signature(rcpt, body)
-    if not ok:
-        print(json.dumps({"ok": False, "stage": "signature", "reason": why}, ensure_ascii=False)); sys.exit(3)
-    print(json.dumps({"ok": True}, ensure_ascii=False))
+    ap = argparse.ArgumentParser(description='Pocket verifier for AI Trust receipts')
+    ap.add_argument('receipt')
+    ap.add_argument('--jwks', required=True)
+    ap.add_argument('--input')
+    ap.add_argument('--output')
+    args = ap.parse_args()
+    with open(args.receipt, 'r', encoding='utf-8') as f:
+        receipt = json.load(f)
+    jwks = load_jwks(args.jwks)
+    input_data = json.load(open(args.input)) if args.input else None
+    output_data = json.load(open(args.output)) if args.output else None
+    ok, reasons = verify(receipt, jwks, input_data, output_data)
+    result = {'valid': ok, 'reasons': reasons, 'warnings': []}
+    print(json.dumps(result, indent=2))
+    sys.exit(0 if ok else 2)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- define JSON Schema for AI receipts with explicit fields and constraints
- add lightweight offline `pocket_verifier` implementing JCS canonicalization and Ed25519 frame verification
- provide Unicode-aware test vectors and schema tests

## Testing
- `pytest tests/test_pocket_verifier.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b637e77e5c832f90aa111df681a962