### PR TITLE
Add receipt schema v1 with test vectors and conformance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Thumbs.db
 htmlcov/
 .pytest_cache/
 mypy_cache/
+node_modules/

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -1,0 +1,32 @@
+# Wire Format
+
+This document describes the canonical wire representation for AI Trust receipts.
+
+## Canonical JSON
+
+Receipts are canonicalized using the [JSON Canonicalization Scheme](https://datatracker.ietf.org/doc/html/rfc8785) (JCS). Keys are sorted, strings are encoded in NFC, numbers use the shortest round-trip form, and no superfluous whitespace is included.
+
+## Timestamps
+
+`issued_at` values use ISO‑8601 in UTC with a trailing `Z` (e.g. `2024-01-20T12:34:56Z`).
+
+## Signature Frame
+
+The bytes signed for the `signature` field are constructed as:
+
+```
+FRAME = DOMAIN || ts_be64_ms || nonce_bytes || JCS(payload)
+```
+
+* `DOMAIN` is an application-specific constant.
+* `ts_be64_ms` is the timestamp in milliseconds since epoch encoded as 64‑bit big‑endian.
+* `nonce_bytes` is the raw 16‑byte value corresponding to the `nonce` string.
+* `JCS(payload)` is the canonicalized JSON of the receipt fields excluding `signature`.
+
+## Regex Summary
+
+Key regular expressions from `receipt-v1.schema.json`:
+
+* Nonce: `^[A-Za-z0-9_-]{22,24}$`
+* Hash: `^sha256:[A-Za-z0-9_-]{43,}$`
+* Signature: `^[A-Za-z0-9_-]{86}$`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "ai-accountability-infrastructure",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-accountability-infrastructure",
+      "devDependencies": {
+        "ajv": "^8.12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ai-accountability-infrastructure",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "ajv": "^8.12.0"
+  },
+  "scripts": {
+    "test:schema": "node tests/js/test-schema.js"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyjwt>=2.6.0",
     "httpx>=0.24.0",
     "typing-extensions>=4.5.0",
+    "jsonschema>=4.18.0",
 ]
 
 [project.optional-dependencies]

--- a/schemas/receipt-v1.schema.json
+++ b/schemas/receipt-v1.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/receipt-v1.schema.json",
+  "title": "AI Trust Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version","issued_at","nonce","alg","hash_alg","kid",
+    "task_hash","model_hash","input_commitment","output_commitment",
+    "policies","costs","canonical_hash","signature"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "issued_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[^Z]+Z$" },
+    "nonce": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22,24}$" },
+    "alg": { "type": "string", "const": "Ed25519" },
+    "hash_alg": { "type": "string", "const": "SHA-256" },
+    "kid": { "type": "string", "pattern": "^(did:key:[A-Za-z0-9:_-]+|[A-Fa-f0-9]{64})$" },
+    "task_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "model_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "input_commitment": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "output_commitment": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "policies": {
+      "type": "object", "additionalProperties": false,
+      "required": ["satisfied","relaxed"],
+      "properties": {
+        "satisfied": { "type": "array", "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" } },
+        "relaxed":   { "type": "array", "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" } }
+      }
+    },
+    "costs": {
+      "type": "object", "additionalProperties": false,
+      "required": ["latency_ms","energy_j"],
+      "properties": {
+        "latency_ms": { "type": "integer", "minimum": 0 },
+        "energy_j": { "type": "number", "minimum": 0 }
+      }
+    },
+    "payload_summary": { "type": "string", "maxLength": 128 },
+    "canonical_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "signature": { "type": "string", "pattern": "^[A-Za-z0-9_-]{86}$" },
+    "log_id": { "type": "string" },
+    "leaf_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "tree_size": { "type": "integer", "minimum": 0 },
+    "inclusion_proof": {
+      "type": "object", "additionalProperties": false,
+      "required": ["leaf_index","path","path_directions"],
+      "properties": {
+        "leaf_index": { "type": "integer", "minimum": 0 },
+        "path": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9_-]{43,}$" } },
+        "path_directions": { "type": "string", "pattern": "^[LR]+$" }
+      }
+    }
+  }
+}

--- a/schemas/vectors/invalid/issued_at_bad.json
+++ b/schemas/vectors/invalid/issued_at_bad.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2024-01-20T12:34:56+01:00",
+  "nonce": "0X1dCsnryXehEya85MietQ",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "1d32803321072127267fdf530a74f36b5ddb1b56c75c2ae93d8c78c4a1d247d3",
+  "task_hash": "sha256:J0Jhp8B9e4TXj3L1Hev2CBw4h5B7EfhCR8uVk5HunNw",
+  "model_hash": "sha256:0Q_lmYxPbny837RnXyXn_kmAUKd_o5kJh0MytZCLVpQ",
+  "input_commitment": "sha256:_Wz0_zSNmfkd9UrSmaAiRvksA9pKR7Vfv-Dk1ciK2vc",
+  "output_commitment": "sha256:vwjn7oq2gupsWEEsN-42c76ij_8g_VyL8iXxHvGbKdg",
+  "policies": {
+    "satisfied": ["TOS_ACCEPTED"],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 1.23
+  },
+  "canonical_hash": "sha256:73fJYign1MeZWsahX7RzgoJ-hDsOxa_S0KvMBdv4jPg",
+  "signature": "mFn3Ea8z6ZM4ytfbQ8xUgwt8SQNTQ2pZpxz73oEcyTheVMIU-n983MtV-Uec6qeF4NYXGCvQzXJHTlEFJ7yXVg"
+}

--- a/schemas/vectors/invalid/nonce_short.json
+++ b/schemas/vectors/invalid/nonce_short.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2024-01-20T12:34:56Z",
+  "nonce": "short",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "1d32803321072127267fdf530a74f36b5ddb1b56c75c2ae93d8c78c4a1d247d3",
+  "task_hash": "sha256:J0Jhp8B9e4TXj3L1Hev2CBw4h5B7EfhCR8uVk5HunNw",
+  "model_hash": "sha256:0Q_lmYxPbny837RnXyXn_kmAUKd_o5kJh0MytZCLVpQ",
+  "input_commitment": "sha256:_Wz0_zSNmfkd9UrSmaAiRvksA9pKR7Vfv-Dk1ciK2vc",
+  "output_commitment": "sha256:vwjn7oq2gupsWEEsN-42c76ij_8g_VyL8iXxHvGbKdg",
+  "policies": {
+    "satisfied": ["TOS_ACCEPTED"],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 1.23
+  },
+  "canonical_hash": "sha256:73fJYign1MeZWsahX7RzgoJ-hDsOxa_S0KvMBdv4jPg",
+  "signature": "mFn3Ea8z6ZM4ytfbQ8xUgwt8SQNTQ2pZpxz73oEcyTheVMIU-n983MtV-Uec6qeF4NYXGCvQzXJHTlEFJ7yXVg"
+}

--- a/schemas/vectors/invalid/signature_bad.json
+++ b/schemas/vectors/invalid/signature_bad.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2024-01-20T12:34:56Z",
+  "nonce": "0X1dCsnryXehEya85MietQ",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "1d32803321072127267fdf530a74f36b5ddb1b56c75c2ae93d8c78c4a1d247d3",
+  "task_hash": "sha256:J0Jhp8B9e4TXj3L1Hev2CBw4h5B7EfhCR8uVk5HunNw",
+  "model_hash": "sha256:0Q_lmYxPbny837RnXyXn_kmAUKd_o5kJh0MytZCLVpQ",
+  "input_commitment": "sha256:_Wz0_zSNmfkd9UrSmaAiRvksA9pKR7Vfv-Dk1ciK2vc",
+  "output_commitment": "sha256:vwjn7oq2gupsWEEsN-42c76ij_8g_VyL8iXxHvGbKdg",
+  "policies": {
+    "satisfied": ["TOS_ACCEPTED"],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 1.23
+  },
+  "canonical_hash": "sha256:73fJYign1MeZWsahX7RzgoJ-hDsOxa_S0KvMBdv4jPg",
+  "signature": "shortsig"
+}

--- a/schemas/vectors/valid/minimal.json
+++ b/schemas/vectors/valid/minimal.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2024-01-20T12:34:56Z",
+  "nonce": "0X1dCsnryXehEya85MietQ",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "1d32803321072127267fdf530a74f36b5ddb1b56c75c2ae93d8c78c4a1d247d3",
+  "task_hash": "sha256:J0Jhp8B9e4TXj3L1Hev2CBw4h5B7EfhCR8uVk5HunNw",
+  "model_hash": "sha256:0Q_lmYxPbny837RnXyXn_kmAUKd_o5kJh0MytZCLVpQ",
+  "input_commitment": "sha256:_Wz0_zSNmfkd9UrSmaAiRvksA9pKR7Vfv-Dk1ciK2vc",
+  "output_commitment": "sha256:vwjn7oq2gupsWEEsN-42c76ij_8g_VyL8iXxHvGbKdg",
+  "policies": {
+    "satisfied": ["TOS_ACCEPTED"],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 1.23
+  },
+  "canonical_hash": "sha256:73fJYign1MeZWsahX7RzgoJ-hDsOxa_S0KvMBdv4jPg",
+  "signature": "mFn3Ea8z6ZM4ytfbQ8xUgwt8SQNTQ2pZpxz73oEcyTheVMIU-n983MtV-Uec6qeF4NYXGCvQzXJHTlEFJ7yXVg"
+}

--- a/schemas/vectors/valid/with_proof.json
+++ b/schemas/vectors/valid/with_proof.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "issued_at": "2024-01-20T12:34:56Z",
+  "nonce": "0X1dCsnryXehEya85MietQ",
+  "alg": "Ed25519",
+  "hash_alg": "SHA-256",
+  "kid": "1d32803321072127267fdf530a74f36b5ddb1b56c75c2ae93d8c78c4a1d247d3",
+  "task_hash": "sha256:J0Jhp8B9e4TXj3L1Hev2CBw4h5B7EfhCR8uVk5HunNw",
+  "model_hash": "sha256:0Q_lmYxPbny837RnXyXn_kmAUKd_o5kJh0MytZCLVpQ",
+  "input_commitment": "sha256:_Wz0_zSNmfkd9UrSmaAiRvksA9pKR7Vfv-Dk1ciK2vc",
+  "output_commitment": "sha256:vwjn7oq2gupsWEEsN-42c76ij_8g_VyL8iXxHvGbKdg",
+  "policies": {
+    "satisfied": ["TOS_ACCEPTED"],
+    "relaxed": []
+  },
+  "costs": {
+    "latency_ms": 123,
+    "energy_j": 1.23
+  },
+  "payload_summary": "U3VtbWFyeQ",
+  "canonical_hash": "sha256:73fJYign1MeZWsahX7RzgoJ-hDsOxa_S0KvMBdv4jPg",
+  "signature": "mFn3Ea8z6ZM4ytfbQ8xUgwt8SQNTQ2pZpxz73oEcyTheVMIU-n983MtV-Uec6qeF4NYXGCvQzXJHTlEFJ7yXVg",
+  "log_id": "example-log",
+  "leaf_hash": "sha256:DwAYOEbgu-oIYIheGDQw1DgzHiB4wASAfeYxnZQHyhU",
+  "tree_size": 2,
+  "inclusion_proof": {
+    "leaf_index": 0,
+    "path": ["nuJIAy30N3BvapnqiahZNxXhJfRP5Pl_8BhrbJRYOVI"],
+    "path_directions": "L"
+  }
+}

--- a/tests/js/test-schema.js
+++ b/tests/js/test-schema.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv from 'ajv/dist/2020.js';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const schemaPath = path.resolve(__dirname, '../../schemas/receipt-v1.schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+const ajv = new Ajv({strict: false});
+const validate = ajv.compile(schema);
+
+function load(dir) {
+  return fs.readdirSync(dir).filter(f => f.endsWith('.json')).map(f => path.join(dir, f));
+}
+
+for (const file of load(path.resolve(__dirname, '../../schemas/vectors/valid'))) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  if (!validate(data)) {
+    console.error('expected valid but failed:', file, validate.errors);
+    process.exit(1);
+  }
+}
+
+for (const file of load(path.resolve(__dirname, '../../schemas/vectors/invalid'))) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  if (validate(data)) {
+    console.error('expected invalid but passed:', file);
+    process.exit(1);
+  }
+}
+
+console.log('all vectors ok');

--- a/tests/unit/test_receipt_schema.py
+++ b/tests/unit/test_receipt_schema.py
@@ -1,0 +1,32 @@
+"""Conformance tests for receipt-v1 JSON schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "receipt-v1.schema.json"
+VECTORS_DIR = SCHEMA_PATH.parent / "vectors"
+
+with SCHEMA_PATH.open("r", encoding="utf-8") as f:
+    SCHEMA = json.load(f)
+
+
+def load_vectors(kind: str) -> list[Path]:
+    return sorted((VECTORS_DIR / kind).glob("*.json"))
+
+
+@pytest.mark.parametrize("vector", load_vectors("valid"))
+def test_valid_vectors(vector: Path) -> None:
+    data = json.loads(vector.read_text())
+    validate(instance=data, schema=SCHEMA)
+
+
+@pytest.mark.parametrize("vector", load_vectors("invalid"))
+def test_invalid_vectors(vector: Path) -> None:
+    data = json.loads(vector.read_text())
+    with pytest.raises(ValidationError):
+        validate(instance=data, schema=SCHEMA)


### PR DESCRIPTION
## Summary
- publish Draft 2020-12 JSON schema for AI Trust Receipt v1
- document canonical wire format and signature frame
- add Python and Node conformance tests using shared valid and invalid vectors

## Testing
- `pytest tests/unit/test_receipt_schema.py`
- `npm run test:schema`


------
https://chatgpt.com/codex/tasks/task_b_68b63bcd7204832f88a03b0d47691036