### PR TITLE
Refine receipt schema field validations

### DIFF
--- a/schemas/receipt-v1.schema.json
+++ b/schemas/receipt-v1.schema.json
@@ -11,44 +11,134 @@
   ],
   "properties": {
     "schema_version": { "const": "1.0" },
-    "issued_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[^Z]+Z$" },
-    "nonce": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22,24}$" },
-    "alg": { "type": "string", "const": "Ed25519" },
-    "hash_alg": { "type": "string", "const": "SHA-256" },
-    "kid": { "type": "string", "pattern": "^(did:key:[A-Za-z0-9:_-]+|[A-Fa-f0-9]{64})$" },
-    "task_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
-    "model_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
-    "input_commitment": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
-    "output_commitment": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
+    "issued_at": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{3})?Z$",
+      "description": "ISO-8601 UTC timestamp with Z suffix"
+    },
+    "nonce": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{22,24}$",
+      "description": "Base64url-encoded random nonce, at least 16 bytes"
+    },
+    "alg": {
+      "type": "string",
+      "const": "Ed25519",
+      "description": "Signature algorithm"
+    },
+    "hash_alg": {
+      "type": "string",
+      "const": "SHA-256",
+      "description": "Hash algorithm used for commitments"
+    },
+    "kid": {
+      "type": "string",
+      "pattern": "^(did:key:[A-Za-z0-9:_-]+|[A-Fa-f0-9]{64})$",
+      "description": "Key identifier - either DID or hex fingerprint"
+    },
+    "task_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Hash of task definition/prompt"
+    },
+    "model_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Hash of model identifier and configuration"
+    },
+    "input_commitment": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Commitment to minimized input data"
+    },
+    "output_commitment": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Commitment to minimized output data"
+    },
     "policies": {
-      "type": "object", "additionalProperties": false,
+      "type": "object",
+      "additionalProperties": false,
       "required": ["satisfied","relaxed"],
       "properties": {
-        "satisfied": { "type": "array", "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" } },
-        "relaxed":   { "type": "array", "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" } }
+        "satisfied": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" },
+          "description": "Policy constraints that were satisfied"
+        },
+        "relaxed": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z_0-9]{3,}$" },
+          "description": "Policy constraints that were relaxed"
+        }
       }
     },
     "costs": {
-      "type": "object", "additionalProperties": false,
+      "type": "object",
+      "additionalProperties": false,
       "required": ["latency_ms","energy_j"],
       "properties": {
-        "latency_ms": { "type": "integer", "minimum": 0 },
-        "energy_j": { "type": "number", "minimum": 0 }
+        "latency_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Processing latency in milliseconds"
+        },
+        "energy_j": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Energy consumed in joules"
+        }
       }
     },
-    "payload_summary": { "type": "string", "maxLength": 128 },
-    "canonical_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
-    "signature": { "type": "string", "pattern": "^[A-Za-z0-9_-]{86}$" },
-    "log_id": { "type": "string" },
-    "leaf_hash": { "type": "string", "pattern": "^sha256:[A-Za-z0-9_-]{43,}$" },
-    "tree_size": { "type": "integer", "minimum": 0 },
+    "payload_summary": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional human-readable summary"
+    },
+    "canonical_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Hash of JCS-canonicalized receipt (excluding signature)"
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{86}$",
+      "description": "Ed25519 signature over canonical hash"
+    },
+    "log_id": {
+      "type": "string",
+      "description": "Optional transparency log identifier"
+    },
+    "leaf_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9_-]{43,}$",
+      "description": "Hash of this receipt as a Merkle tree leaf"
+    },
+    "tree_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Size of Merkle tree when this receipt was added"
+    },
     "inclusion_proof": {
-      "type": "object", "additionalProperties": false,
+      "type": "object",
+      "additionalProperties": false,
       "required": ["leaf_index","path","path_directions"],
       "properties": {
-        "leaf_index": { "type": "integer", "minimum": 0 },
-        "path": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9_-]{43,}$" } },
-        "path_directions": { "type": "string", "pattern": "^[LR]+$" }
+        "leaf_index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Index of this leaf in the Merkle tree"
+        },
+        "path": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Za-z0-9_-]{43,}$" },
+          "description": "Sibling hashes for inclusion proof"
+        },
+        "path_directions": {
+          "type": "string",
+          "pattern": "^[LR]*$",
+          "description": "Path directions (L=left, R=right)"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- document receipt fields with detailed descriptions
- tighten `issued_at` timestamp pattern and allow empty inclusion path directions

## Testing
- `pytest tests/unit/test_receipt_schema.py`


------
https://chatgpt.com/codex/tasks/task_b_68b63d6567c4832fa3c3595002d9cd09