### PR TITLE
fix debug receipt timestamps and document secret key override

### DIFF
--- a/config/debug_receipt.json
+++ b/config/debug_receipt.json
@@ -1,7 +1,7 @@
 {
   "receipt_version": "1.0",
   "execution_id": "test-execution-123",
-  "issued_at": "2025-09-02 01:59:11.159879",
+  "issued_at": "2025-09-02T01:59:11.159879Z",
   "issuer": "https://example.com/",
   "model": {
     "name": "gpt-4",
@@ -17,7 +17,7 @@
     "alg": "EdDSA",
     "kid": "test-key",
     "sig": "MWBZ7E0Cdqo-wqDdL9GX4HW0gG55okjY01qct1W6NUVjuz5sj8Yq-VBAcyaHixlWdl4ddS7POdhoISShVX7fDQ",
-    "issued_at": "2025-09-02 01:59:11.168770"
+    "issued_at": "2025-09-02T01:59:11.168770Z"
   },
   "inputs": null,
   "log_entries": null,

--- a/config/default.toml
+++ b/config/default.toml
@@ -9,6 +9,9 @@ url = "sqlite:///./ai_trust.db"
 echo = false
 
 [security]
+# It is CRITICAL to override this in production environments using environment variables
+# (e.g., SECRET_KEY = os.getenv("SECRET_KEY", "change-me-in-production"))
+# or a dedicated secrets management system.
 secret_key = "change-me-in-production"
 algorithm = "HS256"
 access_token_expire_minutes = 30


### PR DESCRIPTION
## Summary
- use RFC3339 timestamps in `debug_receipt.json`
- clarify that `SECRET_KEY` must be overridden in production

## Testing
- `pytest`
- `npm run test:schema`


------
https://chatgpt.com/codex/tasks/task_b_68b646411f14832fa05006acc8d4d7d9