### PR TITLE
feat: add gatekeeper event schema and metrics tools

### DIFF
--- a/.github/workflows/validate-events.yml
+++ b/.github/workflows/validate-events.yml
@@ -1,0 +1,13 @@
+name: validate-events
+on: [push, pull_request]
+jobs:
+  schema-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install jsonschema ruff pytest
+      - run: ruff check .
+      - run: pytest -q

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,75 @@
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request
+from jsonschema import ValidationError, validate
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+from prometheus_client import Counter, Histogram, make_asgi_app
+
+SCHEMA = json.loads(Path("schemas/gatekeeper.event.v1.json").read_text())
+EVENTS_LOG = Path("data/events.ndjson")
+EVENTS_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+APP = FastAPI(title="Gatekeeper Metrics Ingest")
+tracer = trace.get_tracer("gatekeeper.ingest")
+
+REQS = Counter(
+    "gk_requests_total", "events by action", ["action", "gate_id"]
+)
+LAT = Histogram(
+    "gk_decision_latency_ms",
+    "decision latency ms",
+    buckets=(5, 10, 20, 50, 100, 200, 500, 1000, 2000),
+)
+
+
+@APP.post("/ingest")
+async def ingest(evt: dict, req: Request):
+    t0 = time.perf_counter()
+    with tracer.start_as_current_span("ingest") as span:
+        try:
+            validate(instance=evt, schema=SCHEMA)
+        except ValidationError as e:
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise HTTPException(
+                status_code=400, detail=f"schema_error: {e.message}"
+            ) from e
+
+        if evt["decision"]["reason_code"].upper() == "MISC":
+            raise HTTPException(status_code=422, detail="reason_code MISC is forbidden")
+
+        canon = json.dumps(evt, separators=(",", ":"), sort_keys=True).encode()
+        evt_hash = "sha256:" + hashlib.sha256(canon).hexdigest()
+
+        span.set_attributes(
+            {
+                "gate.id": evt["gate"]["id"],
+                "gate.version": evt["gate"]["version"],
+                "decision.action": evt["decision"]["action"],
+                "decision.reason_code": evt["decision"]["reason_code"],
+                "request.id": evt["request"]["request_id"],
+                "event.hash": evt_hash,
+            }
+        )
+
+        with EVENTS_LOG.open("ab") as f:
+            f.write(canon + b"\n")
+
+        LAT.observe(evt["telemetry"]["latency_ms"])
+        REQS.labels(evt["decision"]["action"], evt["gate"]["id"]).inc()
+
+        span.set_status(Status(StatusCode.OK))
+        return {
+            "ok": True,
+            "event_hash": evt_hash,
+            "received_at": datetime.now(timezone.utc).isoformat(),
+            "elapsed_ms": int((time.perf_counter() - t0) * 1000),
+        }
+
+
+APP.mount("/metrics", make_asgi_app())
+

--- a/config/reason_codes.yaml
+++ b/config/reason_codes.yaml
@@ -1,0 +1,10 @@
+HATE_ABUSE: Hate or abusive content
+SEXUAL_CONTENT: Sexual content policy violation
+PRIVACY_PII: Personal data exposure risk
+MALWARE: Malware or exploit content
+SELF_HARM: Self-harm risk
+VIOLENCE: Threats or violent content
+IP_LEAK: Intellectual property leakage
+REGULATORY_J: Jurisdictional restriction
+SAFETY_UNKNOWN: Safety uncertainty requires human review
+

--- a/gatekeeper/constants.py
+++ b/gatekeeper/constants.py
@@ -1,0 +1,5 @@
+BANNER = "Gatekeeper Metrics"
+EVENT_VERSION = "gatekeeper.event.v1"
+POLICY_NAMESPACES = ("gatekeeper", "safety", "compliance")
+REASON_CODE_VOCAB = "config/reason_codes.yaml"
+

--- a/jobs/snapshot.py
+++ b/jobs/snapshot.py
@@ -1,0 +1,98 @@
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+
+
+def main() -> None:
+    events_path = Path("data/events.ndjson")
+    snap_dir = Path("data/snapshots")
+    snap_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    window = {"start": "1970-01-01T00:00:00Z", "end": now.isoformat()}
+
+    con = duckdb.connect(database=":memory:")
+    con.execute(
+        """
+        CREATE TABLE events AS
+        SELECT * FROM read_json_auto(?, format='newline_delimited');
+        """,
+        [str(events_path)],
+    )
+
+    con.execute(
+        """
+        CREATE TABLE f_decisions AS
+        SELECT
+          gate->>'id' AS gate_id,
+          gate->>'version' AS gate_version,
+          decision->>'action' AS action,
+          decision->>'reason_code' AS reason_code,
+          CAST(telemetry->>'latency_ms' AS INTEGER) AS latency_ms,
+          occurred_at
+        FROM events;
+        """
+    )
+
+    agg = con.execute(
+        """
+        SELECT gate_id, gate_version, action,
+               COUNT(*) AS n,
+               approx_quantile(latency_ms, 0.95) AS p95_latency_ms
+        FROM f_decisions
+        GROUP BY 1,2,3
+        ORDER BY 1,2,3;
+        """
+    ).fetch_arrow_table()
+
+    bundle = {
+        "bundle_version": "gatekeeper.snapshot.v1",
+        "window": window,
+        "generated_at": now.isoformat(),
+        "tables": {
+            "decisions_by_action": agg.to_pydict(),
+        },
+    }
+
+    blob = json.dumps(bundle, separators=(",", ":"), sort_keys=True).encode()
+    bundle_hash = "sha256:" + hashlib.sha256(blob).hexdigest()
+    snap_file = snap_dir / f"{now.isoformat()}_{bundle_hash[7:19]}.json"
+    snap_file.write_bytes(blob)
+
+    key_path = Path("keys/snapshot_private.key")
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    if not key_path.exists():
+        key = Ed25519PrivateKey.generate()
+        key_path.write_bytes(
+            key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+        )
+    priv = Ed25519PrivateKey.from_private_bytes(key_path.read_bytes())
+    sig = priv.sign(blob).hex()
+
+    receipt = {
+        "receipt_version": "gatekeeper.metrics.receipt.v1",
+        "bundle_hash": bundle_hash,
+        "window": window,
+        "generated_at": now.isoformat(),
+        "signature_alg": "ed25519",
+        "signature_hex": sig,
+    }
+    receipt_path = Path(str(snap_file) + ".receipt.json")
+    receipt_path.write_text(json.dumps(receipt, indent=2))
+    print(
+        json.dumps({"bundle": str(snap_file), "receipt": str(receipt_path)}, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ dependencies = [
     "httpx>=0.24.0",
     "typing-extensions>=4.5.0",
     "jsonschema>=4.18.0",
+    "prometheus-client>=0.17.0",
+    "opentelemetry-api>=1.19.0",
+    "opentelemetry-sdk>=1.19.0",
+    "duckdb>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/schemas/gatekeeper.event.v1.json
+++ b/schemas/gatekeeper.event.v1.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/gatekeeper.event.v1.json",
+  "title": "gatekeeper.event.v1",
+  "type": "object",
+  "required": [
+    "event_version",
+    "event_id",
+    "occurred_at",
+    "request",
+    "gate",
+    "model",
+    "artifacts",
+    "decision",
+    "telemetry"
+  ],
+  "properties": {
+    "event_version": {"const": "gatekeeper.event.v1"},
+    "event_id": {"type": "string", "format": "uuid"},
+    "occurred_at": {"type": "string", "format": "date-time"},
+    "trace_id": {"type": "string"},
+    "span_id": {"type": "string"},
+    "request": {
+      "type": "object",
+      "required": ["request_id", "session_id", "actor"],
+      "properties": {
+        "request_id": {"type": "string"},
+        "session_id": {"type": "string"},
+        "actor": {
+          "type": "object",
+          "required": ["role"],
+          "properties": {
+            "role": {"type": "string", "enum": ["user", "developer", "operator", "service"]},
+            "tenant": {"type": "string"},
+            "region": {"type": "string"}
+          }
+        }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "required": ["id", "version", "policy_namespace"],
+      "properties": {
+        "id": {"type": "string"},
+        "version": {"type": "string"},
+        "policy_namespace": {"type": "string", "enum": ["gatekeeper", "safety", "compliance"]},
+        "git_commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
+        "model_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["name", "version", "digest"],
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "required": ["input_commitment", "output_commitment"],
+      "properties": {
+        "input_commitment": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "output_commitment": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "aux_digests": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "required": ["action", "reason_code", "confidence"],
+      "properties": {
+        "action": {"type": "string", "enum": ["allow", "block", "review", "defer"]},
+        "reason_code": {"type": "string", "pattern": "^[A-Z]{2,8}_[A-Z0-9]{2,32}$"},
+        "rationale": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "required": ["latency_ms"],
+      "properties": {
+        "latency_ms": {"type": "integer", "minimum": 0},
+        "compute_ms": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/data/events/invalid_event.json
+++ b/tests/data/events/invalid_event.json
@@ -1,0 +1,32 @@
+{
+  "event_version": "gatekeeper.event.v1",
+  "event_id": "00000000-0000-0000-0000-000000000000",
+  "occurred_at": "2024-01-01T00:00:00Z",
+  "request": {
+    "request_id": "req1",
+    "session_id": "sess1",
+    "actor": {"role": "user"}
+  },
+  "gate": {
+    "id": "pre_text_guard",
+    "version": "1.0.0",
+    "policy_namespace": "gatekeeper",
+    "git_commit": "deadbeef",
+    "model_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "model": {
+    "name": "chat",
+    "version": "v1",
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "artifacts": {
+    "input_commitment": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "output_commitment": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "decision": {
+    "action": "allow",
+    "confidence": 0.9
+  },
+  "telemetry": {"latency_ms": 10}
+}
+

--- a/tests/data/events/valid_event.json
+++ b/tests/data/events/valid_event.json
@@ -1,0 +1,42 @@
+{
+  "event_version": "gatekeeper.event.v1",
+  "event_id": "00000000-0000-0000-0000-000000000000",
+  "occurred_at": "2024-01-01T00:00:00Z",
+  "trace_id": "abcd1234",
+  "span_id": "abcd1234",
+  "request": {
+    "request_id": "req1",
+    "session_id": "sess1",
+    "actor": {
+      "role": "user",
+      "tenant": "tenant1",
+      "region": "us"
+    }
+  },
+  "gate": {
+    "id": "pre_text_guard",
+    "version": "1.0.0",
+    "policy_namespace": "gatekeeper",
+    "git_commit": "deadbeef",
+    "model_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "model": {
+    "name": "chat",
+    "version": "v1",
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "artifacts": {
+    "input_commitment": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "output_commitment": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "decision": {
+    "action": "allow",
+    "reason_code": "HATE_ABUSE",
+    "rationale": "ok",
+    "confidence": 0.9
+  },
+  "telemetry": {
+    "latency_ms": 10
+  }
+}
+

--- a/tests/unit/test_gatekeeper_event_schema.py
+++ b/tests/unit/test_gatekeeper_event_schema.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = Path("schemas/gatekeeper.event.v1.json")
+
+
+def load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_valid_event_passes_schema_validation():
+    schema = load_json(SCHEMA_PATH)
+    event = load_json("tests/data/events/valid_event.json")
+    jsonschema.validate(instance=event, schema=schema)
+
+
+def test_invalid_event_fails_schema_validation():
+    schema = load_json(SCHEMA_PATH)
+    bad_event = load_json("tests/data/events/invalid_event.json")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=bad_event, schema=schema)
+

--- a/tools/pocket_verify.py
+++ b/tools/pocket_verify.py
@@ -1,0 +1,34 @@
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print("usage: pocket_verify.py <bundle.json> <receipt.json> <pubkey>")
+        raise SystemExit(1)
+
+    bundle_path = Path(sys.argv[1])
+    receipt_path = Path(sys.argv[2])
+    pubkey_path = Path(sys.argv[3])
+
+    blob = bundle_path.read_bytes()
+    calc = "sha256:" + hashlib.sha256(blob).hexdigest()
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["bundle_hash"] == calc, "bundle hash mismatch"
+
+    pub = Ed25519PublicKey.from_public_bytes(pubkey_path.read_bytes())
+    pub.verify(bytes.fromhex(receipt["signature_hex"]), blob)
+
+    data = json.loads(blob)
+    assert data["bundle_version"] == "gatekeeper.snapshot.v1"
+
+    print("OK: signature and hash verified; window:", data["window"])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/synthetic.py
+++ b/tools/synthetic.py
@@ -1,0 +1,67 @@
+import hashlib
+import random
+import time
+import uuid
+
+import httpx
+
+CODES = [
+    "HATE_ABUSE",
+    "SEXUAL_CONTENT",
+    "PRIVACY_PII",
+    "MALWARE",
+    "SELF_HARM",
+    "VIOLENCE",
+    "IP_LEAK",
+    "REGULATORY_J",
+    "SAFETY_UNKNOWN",
+]
+
+
+def digest(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode()).hexdigest()
+
+
+def main() -> None:
+    for i, rc in enumerate(CODES):
+        evt = {
+            "event_version": "gatekeeper.event.v1",
+            "event_id": str(uuid.uuid4()),
+            "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "trace_id": uuid.uuid4().hex,
+            "span_id": uuid.uuid4().hex[:16],
+            "request": {
+                "request_id": str(uuid.uuid4()),
+                "session_id": "synth",
+                "actor": {"role": "user", "region": "test"},
+            },
+            "gate": {
+                "id": "pre_text_guard",
+                "version": "1.2.3",
+                "policy_namespace": "gatekeeper",
+                "git_commit": "deadbeef",
+                "model_digest": digest("guard:1.2.3"),
+            },
+            "model": {
+                "name": "chat-large",
+                "version": "2025-08-01",
+                "digest": digest("chat-large:2025-08-01"),
+            },
+            "artifacts": {
+                "input_commitment": digest(f"in{i}"),
+                "output_commitment": digest(f"out{i}"),
+            },
+            "decision": {
+                "action": "block" if i % 3 == 0 else "allow",
+                "reason_code": rc,
+                "rationale": "synthetic",
+                "confidence": round(random.uniform(0.6, 0.99), 2),
+            },
+            "telemetry": {"latency_ms": random.choice([12, 18, 25, 40, 80, 160])},
+        }
+        httpx.post("http://localhost:8000/ingest", json=evt, timeout=5)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add canonical `gatekeeper.event.v1` JSON schema
- implement FastAPI ingestion service with Prometheus and OpenTelemetry
- add snapshot job, reason code vocabulary, and pocket verifier
- provide schema validation tests and CI workflow

## Testing
- `ruff check app/main.py jobs/snapshot.py gatekeeper/constants.py tools/pocket_verify.py tools/synthetic.py tests/unit/test_gatekeeper_event_schema.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b646e6caac832f8789875983cfe45f